### PR TITLE
Fix disappearing lines leading to overflow points.

### DIFF
--- a/uniplot/pixel_matrix.py
+++ b/uniplot/pixel_matrix.py
@@ -137,18 +137,12 @@ def render(
             pixels_already_drawn = False
             if indices_slope is None:
                 # That means it's a vertical line
-                step = 1
-                if y_index_stop < y_index_start:
-                    step = -1
-                pixels[y_index_start:y_index_stop:step, x_index_start] = 1
+                pixels[max(y_index_smaller, 0):max(y_index_bigger, 0), x_index_start] = 1
                 pixels_already_drawn = True
 
             elif y_index_start == y_index_stop:
                 # That means it's a horizontal line
-                step = 1
-                if x_index_stop < x_index_start:
-                    step = -1
-                pixels[y_index_start, x_index_start:x_index_stop:step] = 1
+                pixels[y_index_start, max(x_index_smaller, 0):max(x_index_bigger, 0)] = 1
                 pixels_already_drawn = True
 
             elif abs(indices_slope) > 1:


### PR DESCRIPTION
Hi @olavolav,

First of all, awesome tool 👏!

When rendering histograms, I came across cases where bars completely disappear if their height exceeds the y axis limit. Here's an example where two bars are just above the limit.

![up](https://github.com/olavolav/uniplot/assets/1908734/544a9226-e8fd-40e4-8cdc-4e49a8b1c138)

After a quick dive into to the pixel rendering, I think I found the issue. After the [flip of the y index notation](https://github.com/olavolav/uniplot/blob/273bd23ee82a3d82c8dbcef415e7748c504d763c/uniplot/pixel_matrix.py#L45), lines that disappear have a negative `y_index_start` or `y_index_stop`. This is because the treatment interferes with how cases with `y_index_stop > y_index_start` were handled by a negative step size. Since the smaller and bigger indices already existed, the fix was rather trivial :)

Here is a minimal reproducer.

```python
# coding: utf-8
from uniplot import histogram
from sklearn import datasets

d = datasets.load_iris(as_frame=True)["data"]
histogram(d["sepal length (cm)"], y_max=15)
```