### PR TITLE
Fix bin range default check.

### DIFF
--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -134,8 +134,8 @@ def histogram(
     # Histograms usually make sense only with lines
     kwargs["lines"] = kwargs.get("lines", True)
 
-    bins_min_real: float = bins_min or multi_series.y_min()
-    bins_max_real: float = bins_max or multi_series.y_max()
+    bins_min_real: float = bins_min if bins_min is not None else multi_series.y_min()
+    bins_max_real: float = bins_max if bins_max is not None else multi_series.y_max()
     assert bins_max_real > bins_min_real
 
     # Depending on whether the bin limits were supplied as arguments, expand


### PR DESCRIPTION
Hi @olavolav ,

this PR contains a small fix for the evaluation of defaults for the `bins_min` and `bins_max` arguments. I noticed that, when explicitly setting them to 0, the histograms fallback to the min/max of the input series.

I changed the checks to explicitly check for `None`, to avoid `0` being mistakenly interpreted as "ranges not provided".