### PR TITLE
Reduce time delay between header and rest of the plot.

### DIFF
--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -25,10 +25,6 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
     series: MultiSeries = MultiSeries(xs=xs, ys=ys)
     options: Options = validate_and_transform_options(series=series, kwargs=kwargs)
 
-    # Print header
-    for line in sections.generate_header(options):
-        print(line)
-
     # Main loop for interactive mode. Will only be executed once when not in
     # interactive mode.
     continue_looping: bool = True
@@ -51,6 +47,10 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
                 nr_lines_to_erase += len(options.legend_labels)
             elements.erase_previous_lines(nr_lines_to_erase)
 
+        # Print header
+        for line in sections.generate_header(options):
+            print(line)
+        
         for line in sections.generate_body(
             x_axis_labels, y_axis_labels, pixel_character_matrix, options
         ):

--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -1,5 +1,4 @@
 from typing import List, Optional, Any
-
 from uniplot.multi_series import MultiSeries
 from uniplot.options import Options
 from uniplot.param_initializer import validate_and_transform_options
@@ -25,60 +24,75 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
     series: MultiSeries = MultiSeries(xs=xs, ys=ys)
     options: Options = validate_and_transform_options(series=series, kwargs=kwargs)
 
+    print(_generate_plot_str(series, options))
+
     # Main loop for interactive mode. Will only be executed once when not in
     # interactive mode.
-    continue_looping: bool = True
-    loop_iteration: int = 0
-    while continue_looping:
-        # Make sure we stop after first iteration when not in interactive mode
-        if not options.interactive:
-            continue_looping = False
+    while options.interactive:
+        options.interactive = _process_action(options)
+        # Erases the lines bellow the header, to update them
+        _erase_previous_lines(options)
+        # Generate updated plot
+        print(_generate_plot_str(series, options, with_header=False))
 
-        (
-            x_axis_labels,
-            y_axis_labels,
-            pixel_character_matrix,
-        ) = sections.generate_body_raw_elements(series, options)
 
-        # Delete plot before we re-draw
-        if loop_iteration > 0:
-            nr_lines_to_erase = options.height + 4
-            if options.legend_labels is not None:
-                nr_lines_to_erase += len(options.legend_labels)
-            elements.erase_previous_lines(nr_lines_to_erase)
+def _process_action(options: Options) -> bool:
+    # q and Escape will end interactive mode
+    print("Move h/j/k/l, zoom u/n, or r to reset. ESC/q to quit")
+    key_pressed = getch().lower()
 
-        # Print header
-        for line in sections.generate_header(options):
-            print(line)
-        
-        for line in sections.generate_body(
-            x_axis_labels, y_axis_labels, pixel_character_matrix, options
-        ):
-            print(line)
+    if key_pressed == "h":
+        options.shift_view_left()
+    elif key_pressed == "l":
+        options.shift_view_right()
+    elif key_pressed == "j":
+        options.shift_view_down()
+    elif key_pressed == "k":
+        options.shift_view_up()
+    elif key_pressed == "u":
+        options.zoom_in()
+    elif key_pressed == "n":
+        options.zoom_out()
+    elif key_pressed == "r":
+        options.reset_view()
+    elif key_pressed in ["q", "\x1b"]:
+        return False
+    return True
 
-        if options.interactive:
-            print("Move h/j/k/l, zoom u/n, or r to reset. ESC/q to quit")
-            key_pressed = getch().lower()
 
-            if key_pressed == "h":
-                options.shift_view_left()
-            elif key_pressed == "l":
-                options.shift_view_right()
-            elif key_pressed == "j":
-                options.shift_view_down()
-            elif key_pressed == "k":
-                options.shift_view_up()
-            elif key_pressed == "u":
-                options.zoom_in()
-            elif key_pressed == "n":
-                options.zoom_out()
-            elif key_pressed == "r":
-                options.reset_view()
-            elif key_pressed in ["q", "\x1b"]:
-                # q and Escape will end interactive mode
-                continue_looping = False
+def _erase_previous_lines(options: Options) -> None:
+    # Delete plot before we re-draw
+    nr_lines_to_erase = options.height + 4
+    if options.legend_labels is not None:
+        nr_lines_to_erase += len(options.legend_labels)
+    elements.erase_previous_lines(nr_lines_to_erase)
 
-            loop_iteration += 1
+
+def _generate_plot_str_list(
+    series: MultiSeries, options: Options, with_header: bool = True
+) -> List[str]:
+    """Same as 'plot' but the return type is a list of strings. Ignores the
+    `interactive` option.
+
+    Takes series and options as as input
+    """
+    header = sections.generate_header(options) if with_header else []
+    (
+        x_axis_labels,
+        y_axis_labels,
+        pixel_character_matrix,
+    ) = sections.generate_body_raw_elements(series, options)
+
+    body = sections.generate_body(
+        x_axis_labels, y_axis_labels, pixel_character_matrix, options
+    )
+    return header + body
+
+
+def _generate_plot_str(
+    series: MultiSeries, options: Options, with_header: bool = True
+) -> str:
+    return "\n".join(_generate_plot_str_list(series, options, with_header))
 
 
 def plot_to_string(ys: Any, xs: Optional[Any] = None, **kwargs) -> List[str]:
@@ -91,18 +105,7 @@ def plot_to_string(ys: Any, xs: Optional[Any] = None, **kwargs) -> List[str]:
     """
     series: MultiSeries = MultiSeries(xs=xs, ys=ys)
     options: Options = validate_and_transform_options(series=series, kwargs=kwargs)
-
-    header = sections.generate_header(options)
-    (
-        x_axis_labels,
-        y_axis_labels,
-        pixel_character_matrix,
-    ) = sections.generate_body_raw_elements(series, options)
-
-    body = sections.generate_body(
-        x_axis_labels, y_axis_labels, pixel_character_matrix, options
-    )
-    return header + body
+    return _generate_plot_str_list(series, options)
 
 
 #####################################


### PR DESCRIPTION
While this may be strictly less efficient, it makes the header to be plotted roughly at the same time to the rest of the plot, which makes seamless transitions when updating the chart by just re-plotting on top. (otherwise you see the title for a split of a second and then the rest).

When plotting with a loop and a complex enough chart (with title) it should be apparent, you fit the terminal to be exactly on the size of the plot, expecting a clean update, but you get a tittle first and then the rest, breaking the stream-like plotting experience.
