### PR TITLE
Restore packaging metadata in pyproject.toml for 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dev = [
 default-groups = []
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-py-modules = ["uniplot"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["uniplot*"]


### PR DESCRIPTION
Fixes the missing subpackages (uniplot.axis_labels, etc.) by updating pyproject.toml with a setuptools find packag.

Closes #44 